### PR TITLE
Added sessionMaxAge to defaultConfig

### DIFF
--- a/.changeset/cyan-rats-kiss.md
+++ b/.changeset/cyan-rats-kiss.md
@@ -1,0 +1,5 @@
+---
+"astro-kinde": minor
+---
+
+Added sessionMaxAge to defaultConfig to make it possible to edit through astro config file

--- a/package/README.md
+++ b/package/README.md
@@ -67,6 +67,7 @@ kinde({
     callbackUri: "http://localhost:4321/api/kinde/callback",
     signedInUri: "http://localhost:4321",
     signedOutUri: "http://localhost:4321",
+    sessionMaxAge: 3600, // optional, number in seconds, default: 3600
 });
 ```
 

--- a/package/src/api/callback.ts
+++ b/package/src/api/callback.ts
@@ -40,7 +40,11 @@ export const GET: APIRoute = async ({ request, redirect }) => {
 
     // Set the access token in cookies and prepare the redirect response
     const headers = new Headers();
-    setAccessTokenCookie(headers, access_token);
+    setAccessTokenCookie(
+        headers,
+        access_token,
+        config.sessionMaxAge && config.sessionMaxAge
+    );
     headers.append("Location", config.signedInUri);
     return new Response(null, { status: 302, headers: headers });
 };

--- a/package/src/index.ts
+++ b/package/src/index.ts
@@ -13,6 +13,7 @@ const defaultConfig = {
     callbackUri: "",
     signedInUri: "",
     signedOutUri: "",
+    sessionMaxAge: "",
     responseType: "code",
     scope: "openid email profile offline",
 } satisfies Partial<Config>;


### PR DESCRIPTION
Makes session max age editable through astro config.

Default 3600s is too short for my purposes, so it's possible other users would find this change useful.

The change is backwards compatible, it still defaults to 3600s, no need to edit anything if you you're happy with that. 